### PR TITLE
WIP Add machines to cluster config

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rancher/cluster-controller/controller/clusterheartbeat"
 	"github.com/rancher/cluster-controller/controller/clusterprovisioner"
 	"github.com/rancher/cluster-controller/controller/clusterstats"
+	"github.com/rancher/cluster-controller/controller/machinessyncer"
 	machineController "github.com/rancher/machine-controller/controller"
 	"github.com/rancher/types/config"
 )
@@ -21,4 +22,5 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 	clusterstats.Register(management)
 	agent.Register(ctx, management)
 	clusterevents.Register(ctx, management)
+	machinessyncer.Register(management)
 }

--- a/controller/machinessyncer/machinessyncer.go
+++ b/controller/machinessyncer/machinessyncer.go
@@ -1,0 +1,161 @@
+package machinessyncer
+
+import (
+	"fmt"
+
+	"github.com/rancher/types/apis/management.cattle.io/v3"
+	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	finalizerName = "machinesSyncer"
+)
+
+type Syncer struct {
+	Machines v3.MachineInterface
+	Clusters v3.ClusterInterface
+}
+
+func Register(management *config.ManagementContext) {
+	s := &Syncer{
+		Machines: management.Management.Machines(""),
+		Clusters: management.Management.Clusters(""),
+	}
+	management.Management.Machines("").Controller().AddHandler(s.sync)
+}
+
+func (s *Syncer) sync(key string, machine *v3.Machine) error {
+	if machine == nil {
+		return nil
+	}
+	if machine.DeletionTimestamp != nil {
+		return s.removeFromClusterConfig(machine)
+	}
+	return s.addToClusterConfig(machine)
+}
+
+func getClusterName(machine *v3.Machine) string {
+	clusterName := machine.ClusterName
+	if clusterName == "" {
+		clusterName = machine.Spec.ClusterName
+	}
+	return clusterName
+}
+
+func (s *Syncer) addToClusterConfig(machine *v3.Machine) error {
+	clusterName := getClusterName(machine)
+	if clusterName == "" {
+		return nil
+	}
+
+	if machine.Status.NodeConfig == nil {
+		logrus.Infof("Machine node [%s] for cluster [%s] is not provisioned yet", machine.Name, clusterName)
+		return nil
+	}
+
+	cluster, err := s.Clusters.Get(clusterName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if cluster == nil {
+		return fmt.Errorf("Cluster [%s] does not exist", clusterName)
+	}
+
+	if cluster == nil || cluster.Spec.RancherKubernetesEngineConfig == nil {
+		return fmt.Errorf("Cluster [%s] can not accept nodes provisioned by machine", clusterName)
+	}
+
+	// 1. update machine finalizer
+	set := finalizerSet(machine)
+	machineToUpdate := machine.DeepCopy()
+	if !set {
+		machineToUpdate.Finalizers = append(machineToUpdate.Finalizers, finalizerName)
+	}
+	_, err = s.Machines.Update(machineToUpdate)
+	if err != nil {
+		return fmt.Errorf("Failed to update machine [%s] finalizers in cluster [%s]: %v",
+			machine.Name, cluster.Name, err)
+	}
+
+	var updatedNodes []v3.RKEConfigNode
+	needToAdd := true
+	for _, node := range cluster.Spec.RancherKubernetesEngineConfig.Nodes {
+		if node.MachineName == machine.Name {
+			updatedNodes = append(updatedNodes, *machine.Status.NodeConfig)
+			needToAdd = false
+			continue
+		}
+		updatedNodes = append(updatedNodes, node)
+	}
+	if needToAdd {
+		updatedNodes = append(updatedNodes, *machine.Status.NodeConfig)
+	}
+	cluster.Spec.RancherKubernetesEngineConfig.Nodes = updatedNodes
+	_, err = s.Clusters.Update(cluster)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Syncer) removeFromClusterConfig(machine *v3.Machine) error {
+	if len(machine.Finalizers) <= 0 || machine.Finalizers[0] != finalizerName {
+		return nil
+	}
+	cluster, err := s.Clusters.Get(getClusterName(machine), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if cluster == nil || cluster.Spec.RancherKubernetesEngineConfig == nil {
+		s.cleanupFinalizer(machine)
+		return nil
+	}
+
+	var updatedNodes []v3.RKEConfigNode
+	updated := false
+	for _, node := range cluster.Spec.RancherKubernetesEngineConfig.Nodes {
+		if node.MachineName == machine.Name {
+			logrus.Infof("Removing machine [%s] from cluster [%s]", machine.Name, cluster.Name)
+			updated = true
+			continue
+		}
+		updatedNodes = append(updatedNodes, node)
+	}
+	if updated {
+		cluster.Spec.RancherKubernetesEngineConfig.Nodes = updatedNodes
+		_, err := s.Clusters.Update(cluster)
+		if err != nil {
+			return err
+		}
+	}
+
+	s.cleanupFinalizer(machine)
+
+	return nil
+}
+
+func (s *Syncer) cleanupFinalizer(machine *v3.Machine) error {
+	toUpdate := machine.DeepCopy()
+	var finalizers []string
+	for _, finalizer := range machine.Finalizers {
+		if finalizer == finalizerName {
+			continue
+		}
+		finalizers = append(finalizers, finalizer)
+	}
+	toUpdate.Finalizers = finalizers
+	_, err := s.Machines.Update(toUpdate)
+	return err
+}
+
+func finalizerSet(machine *v3.Machine) bool {
+	for _, value := range machine.Finalizers {
+		if value == finalizerName {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/docker/machine             7246b2c9650c505b6bd3cbeb8b95d0d0f9983f84
 google.golang.org/api                 8cfdc57a0663729cc2811afefb5b7cd3d901e97c
 
 github.com/rancher/norman             8c0d4bfe2e63a801e4e21906d6b37a5173dadcbb
-github.com/rancher/types              9c9def8b3c2631c2b2d9c15df1cca463c5540224
+github.com/rancher/types              911f39fce1fcd298ad937fe84d7114ff813253ea file:///Users/alena/go/src/github.com/rancher/types/.git
 github.com/rancher/kontainer-engine   c9d1e361acee47ca76e563d0b1ee8ce3a3b9ce00
 github.com/rancher/rke                195b5b419ec65b35fc2162edbb8c73150a983bb0
 github.com/rancher/catalog-controller 2fb5db85c14bd0f4f34d1d548a071cc80619a780

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/machine_types.go
@@ -69,6 +69,7 @@ type MachineStatus struct {
 	SSHPrivateKey   string             `json:"sshPrivateKey,omitempty"`
 	ExtractedConfig string             `json:"extractedConfig,omitempty"`
 	Address         string             `json:"address,omitempty"`
+	NodeConfig      *RKEConfigNode     `json:"nodeConfig,omitempty"`
 }
 
 type MachineCondition struct {

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/zz_generated_deepcopy.go
@@ -1525,6 +1525,15 @@ func (in *MachineStatus) DeepCopyInto(out *MachineStatus) {
 			(*out)[key] = val.DeepCopy()
 		}
 	}
+	if in.NodeConfig != nil {
+		in, out := &in.NodeConfig, &out.NodeConfig
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(RKEConfigNode)
+			(*in).DeepCopyInto(*out)
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
The flow:

1) Machine gets added, and provisioned by `machine-controller`
2) Cluster-controller watches for machine events and:
* on add/update, adds or updates corresponding node in `Cluster.RancherKubernetesEngineConfig.Nodes`
* on remove, removes the node from `Cluster.RancherKubernetesEngineConfig.Nodes`
Machine to node lookup is done by node.machineName == machine.Name
As the result, cluster object gets updated

3) ClusterProvisioner controller will get cluster.update event, and call kontainer-engine to update the rke config.

WIP will be removed once kontainer-engine/rke are updated to the latest types (there are some conflicts currently)

@ibuildthecloud @StrongMonkey 

https://github.com/rancher/machine-controller/pull/6