### PR TITLE
Grant users access to CRUD PRTB/CRTB

### DIFF
--- a/controller/auth/project_cluster_handler.go
+++ b/controller/auth/project_cluster_handler.go
@@ -6,7 +6,9 @@ import (
 	corev1 "github.com/rancher/types/apis/core/v1"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	"github.com/rancher/types/config"
+	"github.com/sirupsen/logrus"
 	v12 "k8s.io/api/core/v1"
+	v13 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,8 +16,10 @@ import (
 
 func newPandCLifecycles(management *config.ManagementContext) (*projectLifecycle, *clusterLifecycle) {
 	m := &mgr{
-		mgmt:     management,
-		nsLister: management.Core.Namespaces("").Controller().Lister(),
+		mgmt:       management,
+		nsLister:   management.Core.Namespaces("").Controller().Lister(),
+		prtbLister: management.Management.ProjectRoleTemplateBindings("").Controller().Lister(),
+		crtbLister: management.Management.ClusterRoleTemplateBindings("").Controller().Lister(),
 	}
 	p := &projectLifecycle{
 		mgr: m,
@@ -36,7 +40,7 @@ func (l *projectLifecycle) Create(obj *v3.Project) (*v3.Project, error) {
 		return obj, err
 	}
 
-	err = l.mgr.reconcileCreatorRTB(obj)
+	_, err = l.mgr.reconcileCreatorRTB(obj)
 	return obj, err
 }
 
@@ -62,7 +66,7 @@ func (l *clusterLifecycle) Create(obj *v3.Cluster) (*v3.Cluster, error) {
 		return obj, err
 	}
 
-	err = l.mgr.reconcileCreatorRTB(obj)
+	_, err = l.mgr.reconcileCreatorRTB(obj)
 	return obj, err
 }
 
@@ -76,12 +80,69 @@ func (l *clusterLifecycle) Remove(obj *v3.Cluster) (*v3.Cluster, error) {
 }
 
 type mgr struct {
-	mgmt     *config.ManagementContext
-	nsLister corev1.NamespaceLister
+	mgmt       *config.ManagementContext
+	nsLister   corev1.NamespaceLister
+	prtbLister v3.ProjectRoleTemplateBindingLister
+	crtbLister v3.ClusterRoleTemplateBindingLister
 }
 
-func (m *mgr) reconcileCreatorRTB(obj runtime.Object) error {
-	return nil
+func (m *mgr) reconcileCreatorRTB(obj runtime.Object) (runtime.Object, error) {
+	return v3.CreatorMadeOwner.Do(obj, func() (runtime.Object, error) {
+		metaAccessor, err := meta.Accessor(obj)
+		if err != nil {
+			return obj, err
+		}
+
+		typeAccessor, err := meta.TypeAccessor(obj)
+		if err != nil {
+			return obj, err
+		}
+
+		creatorID, ok := metaAccessor.GetAnnotations()["field.cattle.io/creatorId"]
+		if !ok {
+			logrus.Warnf("%v %v has no creatorId annotation. Cannot add creator as owner", typeAccessor.GetKind(), metaAccessor.GetName())
+			return obj, nil
+		}
+
+		rtbName := "creator"
+		om := v1.ObjectMeta{
+			Name:      rtbName,
+			Namespace: metaAccessor.GetName(),
+		}
+		subject := v13.Subject{
+			Kind: "User",
+			Name: creatorID,
+		}
+
+		switch typeAccessor.GetKind() {
+		case v3.ProjectGroupVersionKind.Kind:
+			if rtb, _ := m.prtbLister.Get(metaAccessor.GetName(), rtbName); rtb != nil {
+				return obj, nil
+			}
+			if _, err := m.mgmt.Management.ProjectRoleTemplateBindings(metaAccessor.GetName()).Create(&v3.ProjectRoleTemplateBinding{
+				ObjectMeta:       om,
+				ProjectName:      metaAccessor.GetName(),
+				RoleTemplateName: "project-owner",
+				Subject:          subject,
+			}); err != nil {
+				return obj, err
+			}
+		case v3.ClusterGroupVersionKind.Kind:
+			if rtb, _ := m.crtbLister.Get(metaAccessor.GetName(), rtbName); rtb != nil {
+				return obj, nil
+			}
+			if _, err := m.mgmt.Management.ClusterRoleTemplateBindings(metaAccessor.GetName()).Create(&v3.ClusterRoleTemplateBinding{
+				ObjectMeta:       om,
+				ClusterName:      metaAccessor.GetName(),
+				RoleTemplateName: "cluster-owner",
+				Subject:          subject,
+			}); err != nil {
+				return obj, err
+			}
+		}
+
+		return obj, nil
+	})
 }
 
 func (m *mgr) reconcileResourceToNamespace(obj runtime.Object) (runtime.Object, error) {

--- a/controller/auth/register.go
+++ b/controller/auth/register.go
@@ -16,6 +16,6 @@ func Register(ctx context.Context, management *config.ManagementContext) {
 	management.Management.ClusterRoleTemplateBindings("").AddLifecycle("mgmt-auth-crtb-controller", crtb)
 	management.Management.GlobalRoles("").AddLifecycle("mgmt-auth-gr-controller", gr)
 	management.Management.GlobalRoleBindings("").AddLifecycle("mgmt-auth-grb-controller", grb)
-	management.Management.Projects("").AddLifecycle("mgmt-project-ns-controller", p)
-	management.Management.Clusters("").AddLifecycle("mgmt-cluster-ns-controller", c)
+	management.Management.Projects("").AddLifecycle("mgmt-project-rbac-controller", p)
+	management.Management.Clusters("").AddLifecycle("mgmt-cluster-rbac-controller", c)
 }

--- a/controller/auth/roletemplatebinding_handler.go
+++ b/controller/auth/roletemplatebinding_handler.go
@@ -2,13 +2,16 @@ package auth
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/rancher/norman/types/slice"
 	"github.com/rancher/types/apis/management.cattle.io/v3"
 	typesrbacv1 "github.com/rancher/types/apis/rbac.authorization.k8s.io/v1"
 	"github.com/rancher/types/config"
 	"k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -22,6 +25,9 @@ func newRTBLifecycles(management *config.ManagementContext) (*prtbLifecycle, *cr
 		mgmt:      management,
 		crbLister: management.RBAC.ClusterRoleBindings("").Controller().Lister(),
 		crLister:  management.RBAC.ClusterRoles("").Controller().Lister(),
+		rLister:   management.RBAC.Roles("").Controller().Lister(),
+		rbLister:  management.RBAC.RoleBindings("").Controller().Lister(),
+		rtLister:  management.Management.RoleTemplates("").Controller().Lister(),
 	}
 	prtb := &prtbLifecycle{
 		mgr:           mgr,
@@ -78,12 +84,16 @@ func (p *prtbLifecycle) ensureBindings(binding *v3.ProjectRoleTemplateBinding) e
 	projectRoleName := strings.ToLower(fmt.Sprintf("%v-projectmember", projectName))
 	clusterRoleName := strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
 
-	if err := p.mgr.ensureBinding(projectRoleName, projectResource, projectName, binding.Subject, binding.ObjectMeta,
+	if err := p.mgr.ensureMembershipBinding(projectRoleName, projectResource, projectName, binding.Subject, binding.ObjectMeta,
 		binding.TypeMeta, proj.ObjectMeta, proj.TypeMeta); err != nil {
 		return err
 	}
-	return p.mgr.ensureBinding(clusterRoleName, clusterResource, clusterName, binding.Subject, binding.ObjectMeta,
-		binding.TypeMeta, cluster.ObjectMeta, cluster.TypeMeta)
+	if err := p.mgr.ensureMembershipBinding(clusterRoleName, clusterResource, clusterName, binding.Subject, binding.ObjectMeta,
+		binding.TypeMeta, cluster.ObjectMeta, cluster.TypeMeta); err != nil {
+		return err
+	}
+
+	return p.mgr.ensureRTBBinding(binding.Namespace, binding.RoleTemplateName, "projectroletemplatebindings", binding.Subject, binding)
 }
 
 type crtbLifecycle struct {
@@ -118,13 +128,20 @@ func (c *crtbLifecycle) ensureBindings(binding *v3.ClusterRoleTemplateBinding) e
 
 	clusterRoleName := strings.ToLower(fmt.Sprintf("%v-clustermember", clusterName))
 
-	return c.mgr.ensureBinding(clusterRoleName, clusterResource, clusterName, binding.Subject, binding.ObjectMeta,
-		binding.TypeMeta, cluster.ObjectMeta, cluster.TypeMeta)
+	if err := c.mgr.ensureMembershipBinding(clusterRoleName, clusterResource, clusterName, binding.Subject, binding.ObjectMeta,
+		binding.TypeMeta, cluster.ObjectMeta, cluster.TypeMeta); err != nil {
+		return err
+	}
+
+	return c.mgr.ensureRTBBinding(binding.Namespace, binding.RoleTemplateName, "clusterroletemplatebindings", binding.Subject, binding)
 }
 
 type manager struct {
 	crLister  typesrbacv1.ClusterRoleLister
+	rLister   typesrbacv1.RoleLister
+	rbLister  typesrbacv1.RoleBindingLister
 	crbLister typesrbacv1.ClusterRoleBindingLister
+	rtLister  v3.RoleTemplateLister
 	mgmt      *config.ManagementContext
 }
 
@@ -157,7 +174,7 @@ func (m *manager) ensureRole(roleName, resource, resourceName string, ownerMeta 
 	return nil
 }
 
-func (m *manager) ensureBinding(roleName, resource, resourceName string, subject v1.Subject, bindingOwnerMeta metav1.ObjectMeta,
+func (m *manager) ensureMembershipBinding(roleName, resource, resourceName string, subject v1.Subject, bindingOwnerMeta metav1.ObjectMeta,
 	bindingOwnerTypeMeta metav1.TypeMeta, roleOwnerMeta metav1.ObjectMeta, roleOwnerTypeMeta metav1.TypeMeta) error {
 	if err := m.ensureRole(roleName, resource, resourceName, roleOwnerMeta, roleOwnerTypeMeta); err != nil {
 		return err
@@ -206,4 +223,187 @@ func (m *manager) ensureBinding(roleName, resource, resourceName string, subject
 		}
 	}
 	return nil
+}
+
+// If the RoleTemplate being bound to grants privileges to PRTB/CRTB, create a role and binding the the project/cluster namespace
+// in the management plane
+func (m *manager) ensureRTBBinding(namespace, roleTemplateName, resource string, subject v1.Subject, binding interface{}) error {
+	metaAccessor, err := meta.Accessor(binding)
+	if err != nil {
+		return err
+	}
+	typeAccessor, err := meta.TypeAccessor(binding)
+	if err != nil {
+		return err
+	}
+
+	// gather roles that have PRTB/CRTB rules
+	rt, err := m.rtLister.Get("", roleTemplateName)
+	if err != nil {
+		return err
+	}
+	allRoles := map[string]*v3.RoleTemplate{}
+	if err := m.gatherRTBRoles(rt, allRoles); err != nil {
+		return err
+	}
+	rtbRoles := map[string]*v3.RoleTemplate{}
+	rtbVerbs := map[string]map[string]bool{}
+	for _, role := range allRoles {
+		verbs := map[string]bool{}
+		rules, err := m.getRules(role)
+		if err != nil {
+			return err
+		}
+		for _, rule := range rules {
+			if (slice.ContainsString(rule.Resources, resource) || slice.ContainsString(rule.Resources, "*")) && len(rule.ResourceNames) == 0 && len(rule.Verbs) > 0 {
+				rtbRoles[role.Name] = role
+				for _, v := range rule.Verbs {
+					verbs[v] = true
+				}
+			}
+		}
+		if len(verbs) > 0 {
+			rtbVerbs[role.Name] = verbs
+		}
+	}
+
+	// if no roles have CRTB/PRTB rules, nothing to do
+	if len(rtbRoles) == 0 {
+		return nil
+	}
+
+	// create or find namespaced roles
+	if err := m.ensureRTBRoles(namespace, resource, rtbRoles, rtbVerbs); err != nil {
+		return err
+	}
+
+	// creating binding for user for each role in namespace
+	bindingCli := m.mgmt.RBAC.RoleBindings(namespace)
+	for roleName := range rtbRoles {
+		bindingName := metaAccessor.GetName()
+		if b, _ := m.rbLister.Get(namespace, bindingName); b != nil {
+			return nil
+		}
+
+		_, err := bindingCli.Create(&v1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: bindingName,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: typeAccessor.GetAPIVersion(),
+						Kind:       typeAccessor.GetKind(),
+						Name:       metaAccessor.GetName(),
+						UID:        metaAccessor.GetUID(),
+					},
+				},
+			},
+			Subjects: []v1.Subject{subject},
+			RoleRef: v1.RoleRef{
+				Kind: "Role",
+				Name: roleName,
+			},
+		})
+
+		if err != nil {
+			return errors.Wrapf(err, "couldn't ensure binding %v %v in %v", roleName, subject.Name, namespace)
+		}
+	}
+
+	return nil
+}
+
+func (m *manager) getRules(role *v3.RoleTemplate) ([]v1.PolicyRule, error) {
+	if !role.External {
+		return role.Rules, nil
+	}
+
+	r, err := m.crLister.Get("", role.Name)
+	if err != nil {
+		return []v1.PolicyRule{}, err
+	}
+
+	return r.Rules, nil
+}
+
+func (m *manager) ensureRTBRoles(namespace, resource string, rts map[string]*v3.RoleTemplate, roleRTBVerbs map[string]map[string]bool) error {
+	roleCli := m.mgmt.RBAC.Roles(namespace)
+	for name, rt := range rts {
+		wantedVerbs, ok := roleRTBVerbs[name]
+		if !ok {
+			return errors.Errorf("couldn't find verbs for %v", name)
+		}
+
+		if role, err := m.rLister.Get(namespace, rt.Name); err == nil && role != nil {
+			currentVerbs := map[string]bool{}
+			for _, rule := range role.Rules {
+				if slice.ContainsString(rule.Resources, resource) {
+					for _, v := range rule.Verbs {
+						currentVerbs[v] = true
+					}
+				}
+			}
+
+			if !reflect.DeepEqual(currentVerbs, wantedVerbs) {
+				role = role.DeepCopy()
+				rules := buildRTBRules(resource, wantedVerbs)
+				role.Rules = rules
+				_, err := roleCli.Update(role)
+				if err != nil {
+					return errors.Wrapf(err, "couldn't update role %v", rt.Name)
+				}
+			}
+			continue
+		}
+
+		rules := buildRTBRules(resource, wantedVerbs)
+		_, err := roleCli.Create(&v1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: rt.Name,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: rt.TypeMeta.APIVersion,
+						Kind:       rt.TypeMeta.Kind,
+						Name:       rt.Name,
+						UID:        rt.UID,
+					},
+				},
+			},
+			Rules: rules,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "couldn't create role %v", rt.Name)
+		}
+	}
+
+	return nil
+}
+
+func (m *manager) gatherRTBRoles(rt *v3.RoleTemplate, roleTemplates map[string]*v3.RoleTemplate) error {
+	roleTemplates[rt.Name] = rt
+
+	for _, rtName := range rt.RoleTemplateNames {
+		subRT, err := m.rtLister.Get("", rtName)
+		if err != nil {
+			return errors.Wrapf(err, "couldn't get RoleTemplate %s", rtName)
+		}
+		if err := m.gatherRTBRoles(subRT, roleTemplates); err != nil {
+			return errors.Wrapf(err, "couldn't gather RoleTemplate %s", rtName)
+		}
+	}
+
+	return nil
+}
+
+func buildRTBRules(resource string, verbs map[string]bool) []v1.PolicyRule {
+	var vs []string
+	for v := range verbs {
+		vs = append(vs, v)
+	}
+	return []v1.PolicyRule{
+		{
+			Resources: []string{resource},
+			Verbs:     vs,
+			APIGroups: []string{"*"},
+		},
+	}
 }

--- a/vendor.conf
+++ b/vendor.conf
@@ -12,7 +12,7 @@ github.com/docker/machine             7246b2c9650c505b6bd3cbeb8b95d0d0f9983f84
 google.golang.org/api                 8cfdc57a0663729cc2811afefb5b7cd3d901e97c
 
 github.com/rancher/norman                     0b2c60dc92c42e315dcc320bd40e01999ca59d66
-github.com/rancher/types                      e33de0139678b3af087928d98a02c1b69cd96807
+github.com/rancher/types                      5b4b8b0b247149948778652926b502195e8407aa
 github.com/rancher/kontainer-engine           4555c8587bf493b0e8fbfbc5bc5bb087beb48153
 github.com/rancher/rke                        e6c3f50a4d25141e86ffefa6a66d951862e60e1e
 github.com/rancher/catalog-controller         e72297f6a3b166be18ae9db19ef59db722ef450b

--- a/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
+++ b/vendor/github.com/rancher/types/apis/management.cattle.io/v3/authz_types.go
@@ -11,6 +11,7 @@ import (
 
 var (
 	NamespaceBackedResource condition.Cond = "BackingNamespaceCreated"
+	CreatorMadeOwner        condition.Cond = "CreatorMadeOwner"
 )
 
 type Project struct {

--- a/vendor/github.com/rancher/types/status/status.go
+++ b/vendor/github.com/rancher/types/status/status.go
@@ -44,6 +44,7 @@ var conditionMappings = []conditionMapping{
 	{Name: "ReplicaFailure", Error: true, FalseIsGood: true},
 	{Name: "Ready", Transition: false, State: "activating"},
 	{Name: "BackingNamespaceCreated", Transition: true, State: "activating"},
+	{Name: "CreatorMadeOwner", Transition: true, State: "activating"},
 }
 
 func Set(data map[string]interface{}) {


### PR DESCRIPTION
Needs https://github.com/rancher/types/pull/94

This change adds a second layer of authorization for ClusterRoleTemplateBindings
and ProjectRoleTemplateBindings. To control who can add users to projects
and clusters, we need to namespace CRTB and PRTB