### PR TITLE
Handle namespaced projects

### DIFF
--- a/controller/auth/project_cluster_handler.go
+++ b/controller/auth/project_cluster_handler.go
@@ -121,7 +121,7 @@ func (m *mgr) reconcileCreatorRTB(obj runtime.Object) (runtime.Object, error) {
 			}
 			if _, err := m.mgmt.Management.ProjectRoleTemplateBindings(metaAccessor.GetName()).Create(&v3.ProjectRoleTemplateBinding{
 				ObjectMeta:       om,
-				ProjectName:      metaAccessor.GetName(),
+				ProjectName:      metaAccessor.GetNamespace() + ":" + metaAccessor.GetName(),
 				RoleTemplateName: "project-owner",
 				Subject:          subject,
 			}); err != nil {

--- a/controller/auth/roletemplatebinding_handler.go
+++ b/controller/auth/roletemplatebinding_handler.go
@@ -63,8 +63,13 @@ func (p *prtbLifecycle) Remove(obj *v3.ProjectRoleTemplateBinding) (*v3.ProjectR
 }
 
 func (p *prtbLifecycle) ensureBindings(binding *v3.ProjectRoleTemplateBinding) error {
-	projectName := binding.ProjectName
-	proj, err := p.projectLister.Get("", projectName)
+	parts := strings.SplitN(binding.ProjectName, ":", 2)
+	if len(parts) < 2 {
+		return errors.Errorf("cannot determine project and cluster from %v", binding.ProjectName)
+	}
+	clusterName := parts[0]
+	projectName := parts[1]
+	proj, err := p.projectLister.Get(clusterName, projectName)
 	if err != nil {
 		return err
 	}
@@ -72,7 +77,6 @@ func (p *prtbLifecycle) ensureBindings(binding *v3.ProjectRoleTemplateBinding) e
 		return errors.Errorf("cannot create binding because project %v was not found", projectName)
 	}
 
-	clusterName := proj.Spec.ClusterName
 	cluster, err := p.clusterLister.Get("", clusterName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Projects are now namespaced under clusters. This causes their IDs
to be of the form cluster.Name:project.Name. This change accounts
for that that.