### PR TITLE
Add annotation indicating a rancher system ns

### DIFF
--- a/controller/auth/project_cluster_handler.go
+++ b/controller/auth/project_cluster_handler.go
@@ -161,6 +161,9 @@ func (m *mgr) reconcileResourceToNamespace(obj runtime.Object) (runtime.Object, 
 			_, err := nsClient.Create(&v12.Namespace{
 				ObjectMeta: v1.ObjectMeta{
 					Name: o.GetName(),
+					Annotations: map[string]string{
+						"management.cattle.io/system-namespace": "true",
+					},
 					OwnerReferences: []v1.OwnerReference{
 						{
 							APIVersion: t.GetAPIVersion(),


### PR DESCRIPTION
This will allow us to filter these namespaces out of the api